### PR TITLE
Fix for Acquire Token

### DIFF
--- a/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
+++ b/MicrosoftAzureServiceFabric-AADHelpers/AADTool/Common.ps1
@@ -27,8 +27,8 @@ function GetRESTHeaders()
     $redirectUrl = "urn:ietf:wg:oauth:2.0:oob"
     
     $authenticationContext = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext -ArgumentList $authString, $FALSE
-
-    $accessToken = $authenticationContext.AcquireToken($resourceUrl, $clientId, $redirectUrl, [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::RefreshSession).AccessToken
+    $parameters = [Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters]::new([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::RefreshSession)
+    $accessToken = $authenticationContext.AcquireTokenAsync($resourceUrl, $clientId, $redirectUrl, $parameters).Result.AccessToken
     $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
     $headers.Add("Authorization", $accessToken)
     return $headers


### PR DESCRIPTION
Method invocation failed because [Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext] does not contain a method named 'AcquireToken'.

Issue when trying on PS 5.1 with Az module. The [Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext]::AquireToken() no longer exists as method and has been replaced with [Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext]::AquireTokenAsync() for PS Core compatibility.